### PR TITLE
fixed bug that prevented shift register from updating on construction

### DIFF
--- a/NET/API/Treehopper.Libraries/IO/PortExpander/ShiftOut.cs
+++ b/NET/API/Treehopper.Libraries/IO/PortExpander/ShiftOut.cs
@@ -61,7 +61,7 @@ namespace Treehopper.Libraries.IO.PortExpander
             for (var i = 0; i < numPins; i++)
                 Pins.Add(new ShiftOutPin(this, i));
 
-            Task.Run(() => FlushAsync()).Wait();
+            Task.Run(() => FlushAsync(true)).Wait();
         }
 
         internal void UpdateOutput(ShiftOutPin shiftOutPin)


### PR DESCRIPTION
Since `FlushAsync()` was being called without the force parameter being true, the shift register would not get initialized upon construction.