### PR TITLE
Fix intermittent ObservableCollection reentrancy crash on USB device removal

### DIFF
--- a/NET/API/Treehopper.Desktop/Treehopper.Desktop.csproj
+++ b/NET/API/Treehopper.Desktop/Treehopper.Desktop.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Version>1.11.4</Version>
+    <Version>1.11.5</Version>
     <Company>Treehopper Electronics</Company>
     <Product>Treehopper.Desktop</Product>
     <Authors>Treehopper Electronics</Authors>

--- a/NET/API/Treehopper.Desktop/WinUsb/UsbNotifyWindow.cs
+++ b/NET/API/Treehopper.Desktop/WinUsb/UsbNotifyWindow.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Permissions;
 using System.Text;
@@ -75,24 +74,12 @@ namespace Treehopper.Desktop.WinUsb
                     }
                     else
                     {
-                        var board = Service.Boards
-                            .Where(x => x.Connection.DevicePath.Substring(3).ToLower() ==
-                                        devBroadcastMsg.DevicePath.Substring(3).ToLower())
-                            .FirstOrDefault();
-                        if (board != null)
-                        {
-                            Debug.WriteLine("Removing: " + board);
-                            board.Connection.Dispose(); // kill the connection first
-                            board.Dispose();
-                            if (currentContext == null)
-                            {
-                                Service.Boards.Remove(board);
-                            }
-                            else
-                            {
-                                currentContext.Post(delegate { Service.Boards.Remove(board); }, null);
-                            }
-                        }
+                        // Delegate to the service so the Boards mutation is marshaled onto the consumer's
+                        // SynchronizationContext (the same one add() uses) instead of being applied
+                        // synchronously here, inside the WndProc / CollectionChanged callstack. Mutating the
+                        // ObservableCollection from this device-notification thread threw
+                        // "Cannot change ObservableCollection during a CollectionChanged event."
+                        Service.remove(devBroadcastMsg.DevicePath);
                     }
                 }
             }

--- a/NET/API/Treehopper.Desktop/WinUsb/WinUsbConnectionService.cs
+++ b/NET/API/Treehopper.Desktop/WinUsb/WinUsbConnectionService.cs
@@ -111,6 +111,30 @@ namespace Treehopper.Desktop.WinUsb
             SetupApi.SetupDiDestroyDeviceInfoList(devInfo);
         }
 
+        internal void remove(string matchDevicePath)
+        {
+            // Find the board whose connection matches the removed device. Substring(3) skips the
+            // differing path prefix, matching the comparison convention used elsewhere for these paths.
+            var board = Boards.FirstOrDefault(x =>
+                x.Connection.DevicePath.Substring(3).ToLower() ==
+                matchDevicePath.Substring(3).ToLower());
+            if (board == null)
+                return;
+
+            Debug.WriteLine("Removing: " + board);
+            board.Connection.Dispose(); // kill the connection first (blocking native USB teardown; keep it off the UI thread)
+            board.Dispose();
+
+            // Marshal the ObservableCollection mutation onto the same context add() uses, so every
+            // Boards mutation runs on one thread and never reentrantly inside a CollectionChanged
+            // dispatch. Mutating synchronously on the WM_DEVICECHANGE (devNotify) thread is what threw
+            // "Cannot change ObservableCollection during a CollectionChanged event."
+            if (currentContext == null)
+                Boards.Remove(board);
+            else
+                currentContext.Post(delegate { Boards.Remove(board); }, null);
+        }
+
         public override void Dispose()
         {
             mNotifyWindow.Dispose();


### PR DESCRIPTION
## Problem

An intermittent, unhandled `InvalidOperationException` could crash a consuming process during USB device churn:

```
System.InvalidOperationException: Cannot change ObservableCollection during a CollectionChanged event.
   at System.Collections.ObjectModel.ObservableCollection`1.CheckReentrancy()
   at System.Collections.ObjectModel.ObservableCollection`1.RemoveItem(Int32 index)
   at System.Collections.ObjectModel.Collection`1.Remove(T item)
   at Treehopper.Desktop.WinUsb.UsbNotifyWindow.WindowProc(...)
```

## Root cause

The WinUSB device-notification path mutated the `Boards` `ObservableCollection` on **two different threads with different marshaling**:

- **Adds** flow through `WinUsbConnectionService.add(...)`, which posts `Boards.Add` to the **service's** captured `SynchronizationContext` (the consumer's UI thread).
- **Removes** ran **synchronously inside `UsbNotifyWindow.WindowProc`** on the dedicated device-notify thread, because they used the **window's** `currentContext` — which is *always null*: the `internal UsbNotifyWindow(WinUsbConnectionService)` ctor never captures it.

The SDK subscribes its own `Boards_CollectionChanged` handler. When a consumer *also* subscribes, `CollectionChanged`'s invocation list length exceeds one — the precondition for `CheckReentrancy()` to throw. A `WM_DEVICECHANGE` removal firing on the device-notify thread while the UI thread is mid-dispatch of an add then throws. Timing-dependent, so some enumerations survive and some crash.

## Fix

Make removal symmetric to addition, mirroring the already-correct sibling `LibUsbConnectionService.RemoveDevice` pattern:

- New `WinUsbConnectionService.remove(string)`: looks up the board, disposes the connection/board off the UI thread (keeping the blocking native `WinUsb_AbortPipe`/handle teardown off it), then marshals **only** the `Boards.Remove` onto the service's `SynchronizationContext` — the same context adds use.
- `UsbNotifyWindow.WindowProc` now just delegates: `Service.remove(devBroadcastMsg.DevicePath)`.

Every `Boards` mutation now runs serialized on one thread and never reentrantly inside a `CollectionChanged` dispatch. Connect/disconnect notification semantics are unchanged (board still disposed + removed; Remove `CollectionChanged` still fires).

## Verification

- **Build:** `Treehopper.Desktop.csproj` builds clean for `netstandard2.0` and `netstandard2.1` — 0 errors.
- **Hardware-in-the-loop A/B test** against a real attached Treehopper board (`VID_10C4&PID_8A7E`). Driving the exact reentrancy condition against the real running service on a pumped `SynchronizationContext`:
  - Old inline `Boards.Remove` from inside the dispatch → throws the *exact* reported exception (confirms the repro has teeth).
  - New `remove(...)` from inside the same dispatch → does **not** throw; board is still removed and the Remove notification still fires.

  (Physical hot-plug `WM_DEVICECHANGE` storms weren't generated — no admin for PnP disable/enable — so the reentrancy condition was reproduced deterministically against the real service + board instead.)


